### PR TITLE
Replace deprecated call + safer return value control

### DIFF
--- a/includes/tripal_analysis_interpro.xml_parser.inc
+++ b/includes/tripal_analysis_interpro.xml_parser.inc
@@ -23,23 +23,26 @@ function tripal_analysis_interpro_parseXMLFile($analysis_id, $interproxmlfile,
           $parsego, $query_re, $query_type, $query_uniquename, $job_id, 1);
     }
     else {
+      // Parsing all files in the directory
       $dir_handle = @opendir($interproxmlfile) or die("Unable to open $interproxmlfile");
-      $pattern = $interproxmlfile . "/*.[xX][mM][lL]";
-      $total_files = count(glob($pattern));
-      print "$total_files file(s) to be parsed.\n";
+      $files_to_parse = [];
+      while ($file = readdir($dir_handle)) {
+        if (preg_match("/^.*\.xml/i", $file)) {
+          $files_to_parse[] = $file;
+        }
+      }
 
+      $total_files = count($files_to_parse);
+      $no_file = 0;
       $interval = intval($total_files * 0.01);
       if ($interval == 0) {
         $interval = 1;
       }
-      $no_file = 0;
-
-      // Parsing all files in the directory
-      while ($file = readdir($dir_handle)) {
-        if (preg_match("/^.*\.xml/i", $file)) {
-          tripal_analysis_interpro_parseSingleXMLFile($analysis_id, "$interproxmlfile/$file",
+      print "$total_files file(s) to be parsed.\n";
+      foreach ($files_to_parse as $file) {
+        print "File $no_file of $total_files: $file                       \n";
+        tripal_analysis_interpro_parseSingleXMLFile($analysis_id, "$interproxmlfile/$file",
             $parsego, $query_re, $query_type, $query_uniquename, $job_id, 0, $no_file, $total_files);
-        }
         $no_file ++;
       }
     }

--- a/includes/tripal_analysis_interpro.xml_parser.inc
+++ b/includes/tripal_analysis_interpro.xml_parser.inc
@@ -24,7 +24,7 @@ function tripal_analysis_interpro_parseXMLFile($analysis_id, $interproxmlfile,
     }
     else {
       $dir_handle = @opendir($interproxmlfile) or die("Unable to open $interproxmlfile");
-      $pattern = sql_regcase($interproxmlfile . "/*.xml");
+      $pattern = $interproxmlfile . "/*.[xX][mM][lL]";
       $total_files = count(glob($pattern));
       print "$total_files file(s) to be parsed.\n";
 
@@ -63,7 +63,7 @@ function tripal_analysis_interpro_parseSingleXMLFile($analysis_id, $interproxmlf
 
   // Load the XML file
   $xml =  simplexml_load_file($interproxmlfile);
-  if (!$xml) {
+  if ($xml === FALSE) {
     watchdog('tripal_interpro', "Cannot open XML. Please check that it is valid XML.", NULL, WATCHDOG_ERROR);
     return;
   }


### PR DESCRIPTION
On PHP7 I had to replace a call to sql_regcase which is now deprecated
Also, on my test data I received a "Cannot open XML. Please check that it is valid XML." error while the XML file was present on the disk: it was due to the testing of simplexml_load_file return value.
