### PR TITLE
Fix error when ipterms do not exist

### DIFF
--- a/theme/templates/tripal_feature_interpro_results.tpl.php
+++ b/theme/templates/tripal_feature_interpro_results.tpl.php
@@ -72,6 +72,7 @@ if (property_exists($feature, 'tripal_analysis_interpro')) {
     if(count($results) > 0){
 
       foreach($results as $analysis_id => $details){
+        if(!isset($details['iprterms'])) continue;
         $analysis   = $details['analysis'];
         $iprterms   = $details['iprterms'];
         $format     = $details['format'];


### PR DESCRIPTION
Hello,

When loading interpro scans, some features end up with empty matches and no terms. Looking through the code, I am not sure how could that happen. However, this is causing an issue when visiting the feature page where this error shows up:
```
Notice: Undefined index: iprterms in include() (line 76 of /var/www/html/sites/all/modules/tripal_analysis_interpro/theme/templates/tripal_feature_interpro_results.tpl.php).
Warning: Invalid argument supplied for foreach() in include() (line 122 of /var/www/html/sites/all/modules/tripal_analysis_interpro/theme/templates/tripal_feature_interpro_results.tpl.php).
```

I added a simple but effective fix that checks if the ipterms index exists before attempting to render the results. 

This issue occurred when using PHP7.0 and PHP7.1. It might not happen on PHP 5.x.

Thanks,
Abdullah
Staton Lab