### PR TITLE
Fix go loader

### DIFF
--- a/includes/TripalImporter/InterProImporter.inc
+++ b/includes/TripalImporter/InterProImporter.inc
@@ -303,10 +303,10 @@ class InterProImporter extends TripalImporter {
               $this->loadIprterms($iprterms, $feature_id, $analysisfeature_id);
 
               // get the DB id for the GO database
-              $parsego = chado_get_property(
-                  array('table' => 'analysis', 'id' => $analysis_id),
-                  array('type_name' => 'analysis_interpro_parsego', 'cv_name' => 'tripal')
-                  );
+              //$parsego = chado_get_property(
+              //    array('table' => 'analysis', 'id' => $analysis_id),
+              //    array('type_name' => 'analysis_interpro_parsego', 'cv_name' => 'tripal')
+              //    );
               $go_db_id = chado_query("SELECT db_id FROM {db} WHERE name = 'GO'")->fetchField();
               if ($parsego and !$go_db_id) {
                 watchdog('tr_ipr_parse', 'GO schema not installed in chado. GO terms are not processed.', array(), WATCHDOG_WARNING);


### PR DESCRIPTION
Hello,

This PR addresses an issue where GO terms were skipped because the `$parsego` variable is overridden. I commented out the section that overrides the paramater and now we have a working GO loader. Tested on our live site.

### Testing

1. You can use [tripal_dev_seed](https://github.com/statonlab/tripal_dev_seed) to get IPS files
1. Load the XML file and make sure to check the `Load GO Terms` option.
1. You should find the new GO terms on the feature page within the annotations tab

Thanks!