### PR TITLE
remove parsego overwriting just use whats in the form please

### DIFF
--- a/includes/TripalImporter/InterProImporter.inc
+++ b/includes/TripalImporter/InterProImporter.inc
@@ -302,11 +302,6 @@ class InterProImporter extends TripalImporter {
               $iprterms = $ipr_array['iprterms'];
               $this->loadIprterms($iprterms, $feature_id, $analysisfeature_id);
 
-              // get the DB id for the GO database
-              $parsego = chado_get_property(
-                  array('table' => 'analysis', 'id' => $analysis_id),
-                  array('type_name' => 'analysis_interpro_parsego', 'cv_name' => 'tripal')
-                  );
               $go_db_id = chado_query("SELECT db_id FROM {db} WHERE name = 'GO'")->fetchField();
               if ($parsego and !$go_db_id) {
                 watchdog('tr_ipr_parse', 'GO schema not installed in chado. GO terms are not processed.', array(), WATCHDOG_WARNING);
@@ -456,11 +451,6 @@ class InterProImporter extends TripalImporter {
           $iprterms = $ipr_array['iprterms'];
           $this->loadIprterms($iprterms, $feature_id, $analysisfeature_id);
 
-          // get the DB id for the GO database
-          $parsego = chado_get_property(
-              array('table' => 'analysis', 'id' => $analysis_id),
-              array('type_name' => 'analysis_interpro_parsego', 'cv_name' => 'tripal')
-              );
           $go_db_id = chado_query("SELECT db_id FROM {db} WHERE name='GO'")->fetchField();
           if ($parsego and !$go_db_id) {
             watchdog('tr_ipr_parse', 'GO schema not installed in chado. GO terms are not processed.', array(), WATCHDOG_WARNING);


### PR DESCRIPTION
Resolves #13 .  I  think the need and reasoning for this is pretty simple: the importer has a checkbox for if you are paresing GO or not, but the importer *overwrites your selection* and uses wahtever prop is attached to the analysis, instead.