### PR TITLE
Fix #27

### DIFF
--- a/includes/TripalFields/local__interpro_results/local__interpro_results.inc
+++ b/includes/TripalFields/local__interpro_results/local__interpro_results.inc
@@ -54,6 +54,7 @@ class local__interpro_results extends ChadoField {
 
     if (empty($interpro_results)) {
       unset($entity->{$field_name});
+      $entity->{$field_name}['und'][0][''] = '';
       return;
     }
     $delta = 0;

--- a/includes/TripalFields/local__interpro_results/local__interpro_results.inc
+++ b/includes/TripalFields/local__interpro_results/local__interpro_results.inc
@@ -54,7 +54,9 @@ class local__interpro_results extends ChadoField {
 
     if (empty($interpro_results)) {
       unset($entity->{$field_name});
-      $entity->{$field_name}['und'][0][''] = '';
+      $entity->{$field_name}['und'][0] = array(
+        'value' => ''
+      );
       return;
     }
     $delta = 0;

--- a/includes/TripalFields/local__interpro_results/local__interpro_results.inc
+++ b/includes/TripalFields/local__interpro_results/local__interpro_results.inc
@@ -53,9 +53,10 @@ class local__interpro_results extends ChadoField {
     $interpro_results = tripal_get_interpro_XML_results($record->feature_id);
 
     if (empty($interpro_results)) {
-      unset($entity->{$field_name});
-      $entity->{$field_name}['und'][0] = array(
-        'value' => ''
+      $entity->{$field_name} = array(
+        'und' => array(
+          array('value' => '')
+        )
       );
       return;
     }


### PR DESCRIPTION
Basically, if $entity->{$field_name}['und'][0] is not set in local__interpro_results.inc, Tripal is not going to show anything in the field. (Even if the formatter actually prints something).

This PR set a default value so that "There are no InterPro results for this feature." is actually displayed when there are no results, instead of an empty field.