### PR TITLE
Issue 32 php8 compatibility change

### DIFF
--- a/includes/TripalImporter/InterProImporter.inc
+++ b/includes/TripalImporter/InterProImporter.inc
@@ -491,9 +491,12 @@ class InterProImporter extends TripalImporter {
    * @return
    *   The feature_id of the matching feature or NULL if not found.
    */
-  function matchFeature($seqid, $seqname = '',
+  function matchFeature($seqid, $seqname,
       $query_re, $query_uniquename, $query_type) {
 
+        if (!$seqname) {
+          $seqname = '';
+        }
         $feature = '';
 
         // if a regular expression is provided then pick out the portion requested


### PR DESCRIPTION
A small fix for php8 compatibility as described in issue #32
Remove the default parameter from the function definition and place it in the function code.